### PR TITLE
Fixed Div by 0

### DIFF
--- a/sklearn/matrix.h
+++ b/sklearn/matrix.h
@@ -293,9 +293,9 @@ public:
 				else if (j == i)
 					U[i][j] = 1;
 				else {
-					U[i][j] = matrix[i][j] / L[i][i];
+					U[i][j] = matrix[i][j] / (L[i][i] == 0)? 1: L[i][i];
 					for (k = 0; k < i; k++) {
-						U[i][j] = U[i][j] - ((L[i][k] * U[k][j]) / L[i][i]);
+						U[i][j] = U[i][j] - ((L[i][k] * U[k][j]) / (L[i][i] == 0)? 1: L[i][i]);
 					}
 				}
 			}


### PR DESCRIPTION
Fixed the div by 0 error happening in the Matrix.h header file line 300 and 302 by setting the divisor of the expression to be 1 in the case where L[i][i] is 0: (L[i][i] == 0)? 1: L[i][i]